### PR TITLE
Fix data:image/ handling in metadata views image source helper

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -193,7 +193,7 @@ export const getImageSrcFromMetadataViewsFile = (file) => {
     } else {
       return getIPFSFileURL(file.cid.trim(), null)
     }
-  } else if (file.url.includes('data:image/')) {
+  } else if (file.url && file.url.includes('data:image/')) {
     return file.url
   } else {
     return "/token_placeholder.png"


### PR DESCRIPTION
Reported in https://discord.com/channels/613813861610684416/621847426201944074/1261086832188330055

Maybe also consider using `startsWith` instead of `includes`